### PR TITLE
Remove `samples`field from `History`

### DIFF
--- a/src/callbacks/recorder.jl
+++ b/src/callbacks/recorder.jl
@@ -5,8 +5,6 @@
     steps::Int = 0
     # number of completed steps in current epoch
     stepsepoch::Int = 0
-    # number of seen samples during training, usually `nsteps * batchsize`
-    samples::Int = 0
 end
 
 """
@@ -39,7 +37,6 @@ function on(::BatchEnd, phase::Phase, recorder::Recorder, learner)
     history = learner.cbstate.history[phase]
     history.steps += 1
     history.stepsepoch += 1
-    history.samples += size(learner.batch.xs)[end]
 end
 
 


### PR DESCRIPTION
It caused issues with models that don't take a vector as input since it
assumed so for calculating the batch size.